### PR TITLE
Add example-server executable target for main/Main.hs

### DIFF
--- a/service-benchmark-tool.cabal
+++ b/service-benchmark-tool.cabal
@@ -145,3 +145,30 @@ Executable echo-service
         warp >= 3.0
 
     ghc-options: -Wall -threaded -O2 -with-rtsopts=-N
+
+Executable example-server
+    default-language: Haskell2010
+    hs-source-dirs: main
+    Main-is: Main.hs
+
+    build-depends:
+        service-benchmark-tool,
+
+        aeson >= 0.8,
+        base == 4.*,
+        base-unicode-symbols >= 0.2,
+        bytestring >= 0.10,
+        case-insensitive >= 1.2,
+        configuration-tools >= 0.2.8,
+        http-client >= 0.4,
+        http-types >= 0.8,
+        lens >= 4.6,
+        lifted-base >= 0.2.3,
+        monad-control >= 1.0,
+        mtl >= 2.2,
+        optparse-applicative >= 0.11,
+        scotty >= 0.9.1,
+        text >= 1.2,
+        transformers >= 0.4
+
+    ghc-options: -Wall -threaded -O2 -with-rtsopts=-N


### PR DESCRIPTION
For those of us who use sandboxes, it's helpful to have all files under the umbrella of some cabal-managed target.
