### PR TITLE
Support retries

### DIFF
--- a/src/Network/Benchmark.hs
+++ b/src/Network/Benchmark.hs
@@ -142,7 +142,7 @@ runAction
     → Stat
     → TestAction
     → m Stat
-runAction retries stat action = withLabel ("function", "runAction") $ do
+runAction retries stat action = do
     (t, result) ← timeT $ runEitherT run
     return ∘ seq stat ∘ (stat ⊕) $
         case result of
@@ -150,7 +150,7 @@ runAction retries stat action = withLabel ("function", "runAction") $ do
             Left e → failStat (toSeconds t * 1000) (sshow e)
   where
     run ∷ EitherT TestException m ()
-    run = retryT retries $
+    run = withLabel ("function", "runAction") ∘ retryT retries $
         fmapLT TestException (runTestAction action)
             `catchAny` (throwError ∘ UnexpectedException)
 {-# INLINEABLE runAction #-}


### PR DESCRIPTION
Hi Lars; sorry I took so long to throw this up, I had got sidetracked.

Anyway, you already had stuff in the `Utils` file for retrying with `EitherT`. It's not quite as advanced as the stuff that we're using internally; is this fine, or did you want me to make it support the full range of options (i.e. custom handlers, delays, etc.)?
